### PR TITLE
chore: turn off rule no-shadowed-variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,7 +110,6 @@ module.exports = {
           'no-duplicate-variable': [true, 'check-parameters'],
           'no-implicit-dependencies': [true, 'dev', ['~']],
           'no-reference-import': true,
-          'no-shadowed-variable': true,
           'no-submodule-imports': [true, '~', 'next', 'date-fns'],
           'no-unused-expression': true,
           'only-arrow-functions': [


### PR DESCRIPTION
This rule is covered by ESLint rule no-shadow. I believe it is safe to remove. It is also mentioned in #1 

I'll do a quick skim afterwards in talfro to remove obsolete disabling of this rule after we update the config version.