### PR TITLE
[LEV-1327] March 2022 Overhaul: ESLint 8, remove TSLint

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ This package provides AngelList's `.eslintrc.js` as an extensible shared config.
 
 ## Usage
 
-Our default export contains all of our ESLint rules, including ECMAScript 6+, React, TSLint compat bindings, presets inherited, etc. Thus, there are a ton of peer dependencies to satisfy.
+Our default export contains all of our ESLint rules, including ECMAScript 6+, React, presets inherited, etc. Thus, there are a ton of peer dependencies to satisfy.
 
 ### 1. Install config as dependency
 
 ```sh
-yarn add --dev 'git+https://github.com/venturehacks/eslint-config-angellist#0.3.1'
+yarn add --dev 'git+https://github.com/venturehacks/eslint-config-angellist#1.0.0'
 ```
 
 ### 2. Install all peer dependencies
@@ -18,24 +18,20 @@ If this were a public repository on the npm registry, we could abstract peer dep
 
 ```sh
 yarn add --dev \
-  '@typescript-eslint/eslint-plugin-tslint@3.5.0' \
-  '@typescript-eslint/eslint-plugin@3.5.0' \
-  '@typescript-eslint/parser@3.5.0' \
-  'eslint-config-airbnb-base@14.2.0' \
-  'eslint-config-prettier@6.11.0' \
-  'eslint-import-resolver-typescript@2.0.0' \
-  'eslint-plugin-compat@3.8.0' \
-  'eslint-plugin-import@2.22.0' \
-  'eslint-plugin-jest@23.17.1' \
-  'eslint-plugin-jsx-a11y@6.3.1' \
-  'eslint-plugin-prettier@3.1.4' \
-  'eslint-plugin-react-hooks@4.0.4' \
-  'eslint-plugin-react@7.20.2' \
-  'eslint-plugin-sort-keys-fix@1.1.1' \
-  'eslint-plugin-typescript-sort-keys@1.2.0' \
-  'eslint@7.15.0' \
-  'tslint-config-prettier@1.18.0' \
-  'tslint@6.1.2'
+  '@typescript-eslint/eslint-plugin@5.13.0' \
+  '@typescript-eslint/parser@5.13.0' \
+  'eslint@8.10.0' \
+  'eslint-config-airbnb-base@15.0.0' \
+  'eslint-config-prettier@8.4.0' \
+  'eslint-import-resolver-typescript@2.5.0' \
+  'eslint-plugin-compat@4.0.2' \
+  'eslint-plugin-import@2.25.4' \
+  'eslint-plugin-jest@26.1.1' \
+  'eslint-plugin-jsx-a11y@6.5.1' \
+  'eslint-plugin-prettier@4.0.0' \
+  'eslint-plugin-react@7.29.2' \
+  'eslint-plugin-react-hooks@4.3.0' \
+  'eslint-plugin-typescript-sort-keys@2.1.0'
 ```
 
 ### 3. Modify your ESLint config
@@ -82,11 +78,8 @@ Place these in `package.json`
 ```json
 {
   "scripts": {
-    "eslint": "eslint '**/*.ts*' --format codeframe",
-    "eslint:fix": "eslint '**/*.ts*' --format codeframe --fix",
-    "tslint": "tslint --project . -t grouped",
-    "tslint:fix": "tslint  --project . --fix -t grouped",
-    "tslint:vscode": "tslint --project . -t vscode"
+    "eslint": "eslint '**/*.ts*'",
+    "eslint:fix": "eslint '**/*.ts*' --fix",
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Our default export contains all of our ESLint rules, including ECMAScript 6+, Re
 ### 1. Install config as dependency
 
 ```sh
-yarn add --dev 'git+https://github.com/venturehacks/eslint-config-angellist#1.0.0'
+yarn add --dev 'git+https://github.com/venturehacks/eslint-config-angellist#0.5.1'
 ```
 
 ### 2. Install all peer dependencies

--- a/index.js
+++ b/index.js
@@ -23,7 +23,6 @@ module.exports = {
     'jest',
     'typescript-sort-keys',
     '@typescript-eslint',
-    '@typescript-eslint/tslint',
     'react',
     'react-hooks',
   ],
@@ -57,10 +56,6 @@ module.exports = {
     '@typescript-eslint/ban-ts-ignore': 'off',
     '@typescript-eslint/ban-types': 'error',
     '@typescript-eslint/camelcase': 'off',
-    // '@typescript-eslint/camelcase': ['error', {
-    //   'properties': 'never',
-    //   'allow': ['^UNSAFE_']
-    // }],
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-member-accessibility': 'off',
     '@typescript-eslint/indent': 'off',
@@ -100,44 +95,6 @@ module.exports = {
     '@typescript-eslint/prefer-for-of': 'error',
     '@typescript-eslint/prefer-function-type': 'error',
     '@typescript-eslint/prefer-namespace-keyword': 'error',
-    '@typescript-eslint/tslint/config': [
-      'error',
-      {
-        rules: {
-          'comment-format': [true, 'check-space'],
-          'jsdoc-format': [true, 'check-multiline-start'],
-          'no-duplicate-imports': true,
-          'no-duplicate-variable': [true, 'check-parameters'],
-          'no-implicit-dependencies': [true, 'dev', ['~']],
-          'no-reference-import': true,
-          'no-unused-expression': true,
-          'only-arrow-functions': [
-            true,
-            'allow-declarations',
-            'allow-named-functions',
-          ],
-          'ordered-imports': [
-            true,
-            {
-              'grouped-imports': true,
-              'import-sources-order': 'lowercase-last',
-              'module-source-path': 'full',
-              'named-imports-order': 'lowercase-last',
-            },
-          ],
-          'prefer-conditional-expression': true,
-          quotemark: [true, 'single', 'avoid-escape', 'jsx-double'],
-          'triple-equals': [true, 'allow-null-check'],
-          'variable-name': [
-            true,
-            'ban-keywords',
-            'check-format',
-            'allow-leading-underscore',
-            'allow-pascal-case',
-          ],
-        },
-      },
-    ],
     '@typescript-eslint/type-annotation-spacing': 'off',
     '@typescript-eslint/unified-signatures': 'error',
     'arrow-body-style': 'off',

--- a/index.js
+++ b/index.js
@@ -18,7 +18,6 @@ module.exports = {
     sourceType: 'module',
   },
   plugins: [
-    'sort-keys-fix',
     'import',
     'jest',
     'typescript-sort-keys',
@@ -285,7 +284,6 @@ module.exports = {
       },
     ],
     'sort-keys': 'off',
-    'sort-keys-fix/sort-keys-fix': 'warn',
     'sort-vars': 'error',
     'space-before-function-paren': 'off',
     'typescript-sort-keys/interface': [

--- a/package.json
+++ b/package.json
@@ -15,21 +15,23 @@
   },
   "devDependencies": {
     "auto-changelog": "^1.16.1",
-    "release-it": "^10.4.4",
-    "@typescript-eslint/eslint-plugin": "3.5.0",
-    "@typescript-eslint/parser": "3.5.0",
-    "eslint": "7.15.0",
-    "eslint-config-airbnb-base": "14.2.0",
-    "eslint-config-prettier": "6.11.0",
-    "eslint-import-resolver-typescript": "2.0.0",
-    "eslint-plugin-compat": "3.8.0",
-    "eslint-plugin-import": "2.22.0",
-    "eslint-plugin-jest": "23.17.1",
-    "eslint-plugin-jsx-a11y": "6.3.1",
-    "eslint-plugin-prettier": "3.1.4",
-    "eslint-plugin-react": "7.20.2",
-    "eslint-plugin-react-hooks": "4.0.4",
-    "eslint-plugin-typescript-sort-keys": "1.2.0"
+    "release-it": "^10.4.4"
+  },
+  "peerDependencies": {
+    "@typescript-eslint/eslint-plugin": "5.13.0",
+    "@typescript-eslint/parser": "5.13.0",
+    "eslint": "8.10.0",
+    "eslint-config-airbnb-base": "15.0.0",
+    "eslint-config-prettier": "8.4.0",
+    "eslint-import-resolver-typescript": "2.5.0",
+    "eslint-plugin-compat": "4.0.2",
+    "eslint-plugin-import": "2.25.4",
+    "eslint-plugin-jest": "26.1.1",
+    "eslint-plugin-jsx-a11y": "6.5.1",
+    "eslint-plugin-prettier": "4.0.0",
+    "eslint-plugin-react": "7.29.2",
+    "eslint-plugin-react-hooks": "4.3.0",
+    "eslint-plugin-typescript-sort-keys": "2.1.0"
   },
   "engines": {
     "node": ">= 10.6.3"

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "release-patch": "release-it patch"
   },
   "devDependencies": {
-    "auto-changelog": "^1.16.1",
-    "release-it": "^10.4.4"
+    "auto-changelog": "1.16.4",
+    "release-it": "10.4.5"
   },
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "5.13.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   },
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "3.5.0",
-    "@typescript-eslint/eslint-plugin-tslint": "3.5.0",
     "@typescript-eslint/parser": "3.5.0",
     "eslint": "7.15.0",
     "eslint-config-airbnb-base": "14.2.0",
@@ -33,9 +32,7 @@
     "eslint-plugin-react": "7.20.2",
     "eslint-plugin-react-hooks": "4.0.4",
     "eslint-plugin-sort-keys-fix": "1.1.1",
-    "eslint-plugin-typescript-sort-keys": "1.2.0",
-    "tslint": "6.1.2",
-    "tslint-config-prettier": "1.18.0"
+    "eslint-plugin-typescript-sort-keys": "1.2.0"
   },
   "engines": {
     "node": ">= 10.6.3"

--- a/package.json
+++ b/package.json
@@ -15,9 +15,7 @@
   },
   "devDependencies": {
     "auto-changelog": "^1.16.1",
-    "release-it": "^10.4.4"
-  },
-  "peerDependencies": {
+    "release-it": "^10.4.4",
     "@typescript-eslint/eslint-plugin": "3.5.0",
     "@typescript-eslint/parser": "3.5.0",
     "eslint": "7.15.0",
@@ -31,7 +29,6 @@
     "eslint-plugin-prettier": "3.1.4",
     "eslint-plugin-react": "7.20.2",
     "eslint-plugin-react-hooks": "4.0.4",
-    "eslint-plugin-sort-keys-fix": "1.1.1",
     "eslint-plugin-typescript-sort-keys": "1.2.0"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -202,18 +202,18 @@ atob@^2.1.1:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-auto-changelog@^1.16.1:
-  version "1.16.1"
-  resolved "https://registry.yarnpkg.com/auto-changelog/-/auto-changelog-1.16.1.tgz#8d62a1d3afd72ba848452f9ec9adbb6cb0fd2808"
-  integrity sha512-1OMUN5UWWhKtlEMpGUfbLFcZHDf4IXMNU4SsGs44xTlSBhjgTOx9ukbahoC7hTqIm6+sRAnlAbLY4UjbDZY18A==
+auto-changelog@1.16.4:
+  version "1.16.4"
+  resolved "https://registry.yarnpkg.com/auto-changelog/-/auto-changelog-1.16.4.tgz#5abcce4e92a4f81824000ab2550bc5d2315fc8fb"
+  integrity sha512-h7diyELoq692AA4oqO50ULoYKIomUdzuQ+NW+eFPwIX0xzVbXEu9cIcgzZ3TYNVbpkGtcNKh51aRfAQNef7HVA==
   dependencies:
-    commander "^3.0.1"
-    core-js "^3.2.1"
-    handlebars "^4.1.2"
+    commander "^5.0.0"
+    core-js "^3.6.4"
+    handlebars "^4.7.3"
     lodash.uniqby "^4.7.0"
     node-fetch "^2.6.0"
     parse-github-url "^1.0.2"
-    regenerator-runtime "^0.13.3"
+    regenerator-runtime "^0.13.5"
     semver "^6.3.0"
 
 balanced-match@^1.0.0:
@@ -459,10 +459,10 @@ combined-stream@^1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^3.0.1:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-3.0.2.tgz#6837c3fb677ad9933d1cfba42dd14d5117d6b39e"
-  integrity sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==
+commander@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
+  integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
 
 commander@~2.20.3:
   version "2.20.3"
@@ -672,10 +672,10 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
-core-js@^3.2.1:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.3.3.tgz#b7048d3c6c1a52b5fe55a729c1d4ccdffe0891bb"
-  integrity sha512-0xmD4vUJRY8nfLyV9zcpC17FtSie5STXzw+HyYw2t8IIvmDnbq7RJUULECCo+NstpJtwK9kx8S+898iyqgeUow==
+core-js@^3.6.4:
+  version "3.21.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.21.1.tgz#f2e0ddc1fc43da6f904706e8e955bc19d06a0d94"
+  integrity sha512-FRq5b/VMrWlrmCzwRrpDYNxyHP9BcAZC+xHJaqTgIE5091ZV1NTmyh0sGOg5XqpnHvR0svdy0sv1gWA1zmhxig==
 
 core-util-is@~1.0.0:
   version "1.0.2"
@@ -1233,7 +1233,7 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.2.tgz#6f0952605d0140c1cfdb138ed005775b92d67b02"
   integrity sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==
 
-handlebars@^4.1.2, handlebars@^4.4.0:
+handlebars@^4.4.0:
   version "4.4.5"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.4.5.tgz#1b1f94f9bfe7379adda86a8b73fb570265a0dddd"
   integrity sha512-0Ce31oWVB7YidkaTq33ZxEbN+UDxMMgThvCe8ptgQViymL5DPis9uLdTA13MiRPhgvqyxIegugrP97iK3JeBHg==
@@ -1241,6 +1241,18 @@ handlebars@^4.1.2, handlebars@^4.4.0:
     neo-async "^2.6.0"
     optimist "^0.6.1"
     source-map "^0.6.1"
+  optionalDependencies:
+    uglify-js "^3.1.4"
+
+handlebars@^4.7.3:
+  version "4.7.7"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
+  integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
+  dependencies:
+    minimist "^1.2.5"
+    neo-async "^2.6.0"
+    source-map "^0.6.1"
+    wordwrap "^1.0.0"
   optionalDependencies:
     uglify-js "^3.1.4"
 
@@ -1920,6 +1932,11 @@ minimist@^1.1.3, minimist@^1.2.0:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
 
+minimist@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
 minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
@@ -2406,10 +2423,10 @@ redent@^2.0.0:
     indent-string "^3.0.0"
     strip-indent "^2.0.0"
 
-regenerator-runtime@^0.13.3:
-  version "0.13.3"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
-  integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
+regenerator-runtime@^0.13.5:
+  version "0.13.9"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
+  integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==
 
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"
@@ -2434,7 +2451,7 @@ registry-url@^3.0.3:
   dependencies:
     rc "^1.0.1"
 
-release-it@^10.4.4:
+release-it@10.4.5:
   version "10.4.5"
   resolved "https://registry.yarnpkg.com/release-it/-/release-it-10.4.5.tgz#3130dfba3ced760d08fb7f4a3a94a6da21274f7e"
   integrity sha512-szNizZw8SDe9gVLUqrR8f2RiVkhU3dzP9QUzL7GE1/aiiXjnQoR8CFFxo/cG/Hs5vq/tbFbpJHJrzFmC3J+cVQ==
@@ -3067,6 +3084,11 @@ windows-release@^3.1.0:
   integrity sha512-QTlz2hKLrdqukrsapKsINzqMgOUpQW268eJ0OaOpJN32h272waxR9fkB9VoWRtK7uKHG5EHJcTXQBD8XZVJkFA==
   dependencies:
     execa "^1.0.0"
+
+wordwrap@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+  integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
 wordwrap@~0.0.2:
   version "0.0.3"


### PR DESCRIPTION
## Scope

- ESLint@8
- remove TSLint completely
- remove redundant eslint-plugin-sort-keys-fix (autofix available in other plugin included)
- upgrade all peerDependencies
- README refresh

See commits for more details.

### Jira

https://venturehacks.atlassian.net/browse/LEV-1327